### PR TITLE
feat: Add optional MetalLB and ExternalDNS integration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+# Feature: Optional MetalLB and ExternalDNS Integration
+
+## Description
+This PR adds optional integration with MetalLB and ExternalDNS, allowing for more flexible network configuration of virtual machines.
+
+### Added
+- ExternalDNS Integration:
+  - Enable with `EXTERNAL_DNS_ENABLED=true`
+  - Automatically manages DNS records for VMs
+  - Configurable through hostname field in VM creation
+  - Adds `external-dns.alpha.kubernetes.io/hostname` annotation to Services
+  - Example: `external-dns.alpha.kubernetes.io/hostname: myvm.example.com`
+
+- MetalLB Integration:
+  - Enable with `METALLB_ENABLED=true`
+  - Provides LoadBalancer services for VMs
+  - Configurable IP address pools via annotations
+  - Adds `metallb.universe.tf/address-pool` annotation to Services
+  - Example: `metallb.universe.tf/address-pool: production-pool`
+
+### Changed
+- Improved error handling for Git operations
+- Better feedback for configuration issues
+- Updated documentation for new environment variables
+- Enhanced service configuration options
+- Improved network integration capabilities
+
+## Testing Done
+- Verified MetalLB integration with test VM deployments
+- Confirmed ExternalDNS record creation
+- Tested both features in isolation and together
+- Validated error handling for misconfigured scenarios
+
+## Notes
+- Both features are optional and disabled by default
+- Configuration is done via environment variables
+- Existing deployments without these features will continue to work as before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for custom storage access modes
 - Configurable Git clone directory
 - Enhanced environment variable validation
+- ExternalDNS Integration:
+  - Enable with `EXTERNAL_DNS_ENABLED=true`
+  - Automatically manages DNS records for VMs
+  - Configurable through hostname field in VM creation
+  - Supports multiple DNS providers via ExternalDNS
+  - Adds DNS annotations to Kubernetes Services
+- MetalLB Integration:
+  - Enable with `METALLB_ENABLED=true`
+  - Provides LoadBalancer services for VMs
+  - Configurable IP address pools
+  - Supports both layer 2 and BGP modes
+  - Automatic IP allocation for VM services
 
 ### Changed
 - Improved error handling for Git operations
 - Better feedback for configuration issues
 - Updated documentation for new environment variables
+- Enhanced service configuration options
+- Improved network integration capabilities
 
 ## [1.2.1] - 2025-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Automatically manages DNS records for VMs
   - Configurable through hostname field in VM creation
   - Supports multiple DNS providers via ExternalDNS
-  - Adds DNS annotations to Kubernetes Services
+  - Adds `external-dns.alpha.kubernetes.io/hostname` annotation to Services
+  - Example: `external-dns.alpha.kubernetes.io/hostname: myvm.example.com`
 - MetalLB Integration:
   - Enable with `METALLB_ENABLED=true`
   - Provides LoadBalancer services for VMs
-  - Configurable IP address pools
+  - Configurable IP address pools via annotations
+  - Adds `metallb.universe.tf/address-pool` annotation to Services
+  - Example: `metallb.universe.tf/address-pool: production-pool`
   - Supports both layer 2 and BGP modes
   - Automatic IP allocation for VM services
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Support for custom storage access modes
+- Configurable Git clone directory
+- Enhanced environment variable validation
+
+### Changed
+- Improved error handling for Git operations
+- Better feedback for configuration issues
+- Updated documentation for new environment variables
+
 ## [1.2.1] - 2025-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -127,9 +127,12 @@ Required:
 - `GIT_TOKEN`: Git authentication token
 
 Optional:
-- `SECRET_KEY`: Flask secret key
-- `YAML_SUBDIRECTORY`: VM configuration directory (default: "vms/")
-- `FLASK_ENV`: Application environment
+- `SECRET_KEY`: Flask secret key (default: "dev-secret-key")
+- `YAML_SUBDIRECTORY`: VM configuration directory (default: "virtualmachines/")
+- `GIT_CLONE_DIR`: Directory for Git repository clones (default: "/app/storage/clones")
+- `EXTERNAL_DNS_ENABLED`: Enable ExternalDNS integration (default: "false")
+- `METALLB_ENABLED`: Enable MetalLB integration (default: "false")
+- `FLASK_DEBUG`: Enable debug mode (default: "false")
 
 ### Resource Requirements
 

--- a/app/forms.py
+++ b/app/forms.py
@@ -27,8 +27,17 @@ class VMForm(FlaskForm):
     memory = IntegerField('Memory (GB)', validators=[DataRequired(), NumberRange(min=1, max=64)])
     storage_size = IntegerField('Storage Size (GB)', validators=[DataRequired(), NumberRange(min=1, max=2048)])
     storage_class = StringField('Storage Class', default='longhorn-rwx')
+    storage_access_mode = SelectField('Storage Access Mode', 
+                                    choices=[('ReadWriteMany', 'ReadWriteMany'),
+                                           ('ReadWriteOnce', 'ReadWriteOnce'),
+                                           ('ReadOnlyMany', 'ReadOnlyMany')],
+                                    default='ReadWriteMany')
     image_url = StringField('Image URL', validators=[DataRequired()])
     user_data = TextAreaField('User Data')
-    hostname = StringField('Hostname', validators=[DataRequired()])
-    address_pool = StringField('Address Pool', validators=[DataRequired()])
+    hostname = StringField('Hostname')
+    address_pool = StringField('Address Pool')
+    service_type = SelectField('Service Type',
+                             choices=[('LoadBalancer', 'LoadBalancer'),
+                                    ('ClusterIP', 'ClusterIP')],
+                             default='LoadBalancer')
     service_ports = FieldList(FormField(ServicePortForm), min_entries=1)

--- a/app/routes.py
+++ b/app/routes.py
@@ -77,10 +77,10 @@ def create_vm():
             logger.info(f"Processed service ports: {service_ports_data}")
 
             if 'preview' in request.form:
-                yaml_content = generate_yaml(form_data)
+                yaml_content = generate_yaml(form_data, Config)
                 return render_template('create_vm.html', form=form, preview_yaml=yaml_content)
 
-            yaml_content = generate_yaml(form_data)
+            yaml_content = generate_yaml(form_data, Config)
 
             git_config = {
                 'repo_url': Config.GIT_REPO_URL,
@@ -150,7 +150,7 @@ def edit_vm(vm_name):
             }
 
             if 'preview' in request.form:
-                yaml_content = generate_yaml(form_data)
+                yaml_content = generate_yaml(form_data, Config)
                 return render_template('edit_vm.html', form=form, vm_name=vm_name, preview_yaml=yaml_content)
 
             yaml_content = generate_yaml(form_data, Config)

--- a/app/routes.py
+++ b/app/routes.py
@@ -104,7 +104,7 @@ def create_vm():
         if form.errors:
             logger.error(f"Form validation errors: {form.errors}")
 
-    return render_template('create_vm.html', form=form)
+    return render_template('create_vm.html', form=form, config=Config)
 
 @main.route('/edit/<vm_name>', methods=['GET', 'POST'])
 def edit_vm(vm_name):
@@ -112,7 +112,7 @@ def edit_vm(vm_name):
         if request.method == 'GET':
             vm_config = get_vm_config(Config, vm_name)
             form = VMForm(data=vm_config)
-            return render_template('edit_vm.html', form=form, vm_name=vm_name)
+            return render_template('edit_vm.html', form=form, vm_name=vm_name, config=Config)
 
         form = VMForm()
         if form.validate_on_submit():

--- a/app/routes.py
+++ b/app/routes.py
@@ -153,7 +153,13 @@ def edit_vm(vm_name):
                 yaml_content = generate_yaml(form_data)
                 return render_template('edit_vm.html', form=form, vm_name=vm_name, preview_yaml=yaml_content)
 
-            update_vm_config(Config, vm_name, form_data)
+            yaml_content = generate_yaml(form_data, Config)
+            git_config = {
+                'repo_url': Config.GIT_REPO_URL,
+                'username': Config.GIT_USERNAME,
+                'token': Config.GIT_TOKEN
+            }
+            commit_to_git(yaml_content, vm_name, Config.YAML_SUBDIRECTORY, git_config)
             flash('VM configuration updated successfully!', 'success')
             return redirect(url_for('main.vm_list'))
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -71,7 +71,8 @@ def create_vm():
                 'user_data': form.user_data.data,
                 'hostname': form.hostname.data,
                 'address_pool': form.address_pool.data,
-                'service_ports': service_ports_data
+                'service_ports': service_ports_data,
+                'service_type': form.service_type.data
             }
 
             logger.info(f"Processed service ports: {service_ports_data}")

--- a/app/templates/cluster_vms.html
+++ b/app/templates/cluster_vms.html
@@ -158,16 +158,9 @@
                                 {% for port in vm.service.ports %}
                                     {% if port.port == 22 and not ns.found %}
                                         {% set ns.found = true %}
-                                        {% if vm.service.external_ips %}
-                                            <a href="{{ url_for('main.terminal', vm_name=vm.name, host=vm.service.external_ips[0]) }}" class="btn btn-sm btn-outline-success" target="_blank">
-                                                <i class="bi bi-terminal me-1"></i>Web SSH (External)
-                                            </a>
-                                        {% endif %}
-                                        {% if vm.service.cluster_ip %}
-                                            <a href="{{ url_for('main.terminal', vm_name=vm.name, host=vm.service.cluster_ip) }}" class="btn btn-sm btn-outline-success" target="_blank">
-                                                <i class="bi bi-terminal me-1"></i>Web SSH (Internal)
-                                            </a>
-                                        {% endif %}
+                                        <a href="{{ url_for('main.terminal', vm_name=vm.name, host=vm.service.external_ips[0] if vm.service.external_ips else vm.service.cluster_ip) }}" class="btn btn-sm btn-outline-success" target="_blank">
+                                            <i class="bi bi-terminal me-1"></i>Web SSH
+                                        </a>
                                     {% endif %}
                                 {% endfor %}
                             {% endif %}

--- a/app/templates/cluster_vms.html
+++ b/app/templates/cluster_vms.html
@@ -153,14 +153,21 @@
                             <button type="button" class="btn btn-sm btn-outline-info view-service-yaml" data-service-name="{{ vm.name }}">
                                 <i class="bi bi-code-square me-1"></i>View Service YAML
                             </button>
-                            {% if vm.service.ports and vm.service.external_ips and vm.user_data and 'ssh_pwauth: true' in vm.user_data %}
+                            {% if vm.service.ports and vm.user_data and 'ssh_pwauth: true' in vm.user_data %}
                                 {% set ns = namespace(found=false) %}
                                 {% for port in vm.service.ports %}
                                     {% if port.port == 22 and not ns.found %}
                                         {% set ns.found = true %}
-                                        <a href="{{ url_for('main.terminal', vm_name=vm.name, host=vm.service.external_ips[0]) }}" class="btn btn-sm btn-outline-success" target="_blank">
-                                            <i class="bi bi-terminal me-1"></i>Web SSH
-                                        </a>
+                                        {% if vm.service.external_ips %}
+                                            <a href="{{ url_for('main.terminal', vm_name=vm.name, host=vm.service.external_ips[0]) }}" class="btn btn-sm btn-outline-success" target="_blank">
+                                                <i class="bi bi-terminal me-1"></i>Web SSH (External)
+                                            </a>
+                                        {% endif %}
+                                        {% if vm.service.cluster_ip %}
+                                            <a href="{{ url_for('main.terminal', vm_name=vm.name, host=vm.service.cluster_ip) }}" class="btn btn-sm btn-outline-success" target="_blank">
+                                                <i class="bi bi-terminal me-1"></i>Web SSH (Internal)
+                                            </a>
+                                        {% endif %}
                                     {% endif %}
                                 {% endfor %}
                             {% endif %}

--- a/app/templates/create_vm.html
+++ b/app/templates/create_vm.html
@@ -64,10 +64,12 @@ users:
         <label class="form-label">Service Type</label>
         {{ form.service_type(class="form-control") }}
     </div>
+    {% if config.METALLB_ENABLED %}
     <div class="mb-3">
         <label class="form-label">Address Pool</label>
         {{ form.address_pool(class="form-control", placeholder="Optional - Required for LoadBalancer type") }}
     </div>
+    {% endif %}
 
     <div class="mb-3">
         <label class="form-label">Tags</label>

--- a/app/templates/create_vm.html
+++ b/app/templates/create_vm.html
@@ -37,6 +37,10 @@
         {{ form.storage_class(class="form-control") }}
     </div>
     <div class="mb-3">
+        <label class="form-label">Storage Access Mode</label>
+        {{ form.storage_access_mode(class="form-control") }}
+    </div>
+    <div class="mb-3">
         <label class="form-label">Image URL</label>
         {{ form.image_url(class="form-control") }}
     </div>
@@ -55,8 +59,12 @@ users:
         {{ form.hostname(class="form-control") }}
     </div>
     <div class="mb-3">
+        <label class="form-label">Service Type</label>
+        {{ form.service_type(class="form-control") }}
+    </div>
+    <div class="mb-3">
         <label class="form-label">Address Pool</label>
-        {{ form.address_pool(class="form-control") }}
+        {{ form.address_pool(class="form-control", placeholder="Optional - Required for LoadBalancer type") }}
     </div>
 
     <div class="mb-3">

--- a/app/templates/create_vm.html
+++ b/app/templates/create_vm.html
@@ -67,7 +67,7 @@ users:
     {% if config.METALLB_ENABLED %}
     <div class="mb-3">
         <label class="form-label">Address Pool</label>
-        {{ form.address_pool(class="form-control", placeholder="Optional - Required for LoadBalancer type") }}
+        {{ form.address_pool(class="form-control", placeholder="Optional - Only used if MetalLB is configured") }}
     </div>
     {% endif %}
 

--- a/app/templates/create_vm.html
+++ b/app/templates/create_vm.html
@@ -54,10 +54,12 @@ users:
     groups: sudo
     shell: /bin/bash") }}
     </div>
+    {% if config.EXTERNAL_DNS_ENABLED %}
     <div class="mb-3">
         <label class="form-label">Hostname</label>
-        {{ form.hostname(class="form-control") }}
+        {{ form.hostname(class="form-control", placeholder="Optional - Only used if ExternalDNS is configured") }}
     </div>
+    {% endif %}
     <div class="mb-3">
         <label class="form-label">Service Type</label>
         {{ form.service_type(class="form-control") }}

--- a/app/templates/edit_vm.html
+++ b/app/templates/edit_vm.html
@@ -45,10 +45,12 @@
             <label class="form-label">User Data</label>
             {{ form.user_data(class="form-control", rows="10") }}
         </div>
+        {% if config.EXTERNAL_DNS_ENABLED %}
         <div class="mb-3">
             <label class="form-label">Hostname</label>
-            {{ form.hostname(class="form-control") }}
+            {{ form.hostname(class="form-control", placeholder="Optional - Only used if ExternalDNS is configured") }}
         </div>
+        {% endif %}
         <div class="mb-3">
             <label class="form-label">Address Pool</label>
             {{ form.address_pool(class="form-control") }}

--- a/app/templates/edit_vm.html
+++ b/app/templates/edit_vm.html
@@ -51,10 +51,12 @@
             {{ form.hostname(class="form-control", placeholder="Optional - Only used if ExternalDNS is configured") }}
         </div>
         {% endif %}
+        {% if config.METALLB_ENABLED %}
         <div class="mb-3">
             <label class="form-label">Address Pool</label>
             {{ form.address_pool(class="form-control") }}
         </div>
+        {% endif %}
 
         <div class="mb-3">
             <label class="form-label">Tags</label>

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-{%- if address_pool or hostname %}
+  {%- if address_pool or hostname %}
   annotations:
     {%- if address_pool %}
     metallb.universe.tf/address-pool: {{ address_pool }}
@@ -9,7 +9,7 @@ metadata:
     {%- if hostname %}
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
     {%- endif %}
-{%- endif %}
+  {%- endif %}
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -4,16 +4,15 @@ metadata:
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}
-{%- if address_pool or hostname %}
+{% if address_pool or hostname %}
   annotations:
-    {%- if address_pool %}
+{% if address_pool %}
     metallb.universe.tf/address-pool: {{ address_pool }}
-    {%- endif %}
-    {%- if hostname %}
+{% endif %}
+{% if hostname %}
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
-    {%- endif %}
-{%- endif %}
-
+{% endif %}
+{% endif %}
 spec:
   ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -4,7 +4,7 @@ metadata:
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}
-  {%- if address_pool or hostname %}
+{%- if address_pool or hostname %}
   annotations:
     {%- if address_pool %}
     metallb.universe.tf/address-pool: {{ address_pool }}
@@ -12,7 +12,7 @@ metadata:
     {%- if hostname %}
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
     {%- endif %}
-  {%- endif %}
+{%- endif %}
 spec:
   ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -25,5 +25,5 @@ spec:
 {% endfor %}
   selector:
     kubevirt.io/vm: {{ vm_name }}
-  type: {{ service_type }}
+  type: {{ service_type if service_type else 'LoadBalancer' }}
 

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -17,12 +17,12 @@ spec:
   ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local
   ports:
-  {%- for port in service_ports %}
+{%- for port in service_ports %}
   - name: {{ port.port_name }}
     port: {{ port.port }}
     protocol: {{ port.protocol }}
     targetPort: {{ port.targetPort }}
-  {%- endfor %}
+{%- endfor %}
   selector:
     kubevirt.io/vm: {{ vm_name }}
   type: LoadBalancer

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {%- if address_pool or hostname %}
   annotations:
     {%- if address_pool %}
     metallb.universe.tf/address-pool: {{ address_pool }}
@@ -8,7 +9,7 @@ metadata:
     {%- if hostname %}
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
     {%- endif %}
-  {%- if not address_pool and not hostname %}
+  {%- else %}
   annotations: {}
   {%- endif %}
   labels:

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -26,5 +26,4 @@ spec:
   selector:
     kubevirt.io/vm: {{ vm_name }}
   type: {{ service_type }}
-status:
-  loadBalancer: {}
+

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -25,5 +25,5 @@ spec:
 {% endfor %}
   selector:
     kubevirt.io/vm: {{ vm_name }}
-  type: {{ service_type if service_type else 'LoadBalancer' }}
+  type: {{ service_type }}
 

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -2,25 +2,25 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    {% if address_pool %}metallb.universe.tf/address-pool: {{ address_pool }}{% endif %}
-    {% if hostname %}external-dns.alpha.kubernetes.io/hostname: {{ hostname }}{% endif %}
+    {%- if address_pool %}
+    metallb.universe.tf/address-pool: {{ address_pool }}
+    {%- endif %}
+    {%- if hostname %}
+    external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
+    {%- endif %}
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}
 spec:
-  {% if service_type == 'LoadBalancer' %}
-  ipFamilyPolicy: PreferDualStack
-  externalTrafficPolicy: Local
-  {% endif %}
   ports:
-{% for port in service_ports %}
+  {%- for port in service_ports %}
   - name: {{ port.port_name }}
     port: {{ port.port }}
     protocol: {{ port.protocol }}
     targetPort: {{ port.targetPort }}
-{% endfor %}
+  {%- endfor %}
   selector:
     kubevirt.io/vm: {{ vm_name }}
-  type: {{ service_type }}
+  type: {{ service_type if service_type else 'ClusterIP' }}
 status:
   loadBalancer: {}

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -25,6 +25,6 @@ spec:
 {% endfor %}
   selector:
     kubevirt.io/vm: {{ vm_name }}
-  type: LoadBalancer
+  type: {{ service_type }}
 status:
   loadBalancer: {}

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,15 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-{%- if address_pool or hostname %}
   annotations:
-    {%- if address_pool %}
     metallb.universe.tf/address-pool: {{ address_pool }}
-    {%- endif %}
-    {%- if hostname %}
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
-    {%- endif %}
-{%- endif %}
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}
@@ -17,12 +11,12 @@ spec:
   ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local
   ports:
-{%- for port in service_ports %}
+{% for port in service_ports %}
   - name: {{ port.port_name }}
     port: {{ port.port }}
     protocol: {{ port.protocol }}
     targetPort: {{ port.targetPort }}
-{%- endfor %}
+{% endfor %}
   selector:
     kubevirt.io/vm: {{ vm_name }}
   type: LoadBalancer

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    kubevirt.io/vm: {{ vm_name }}
+  name: {{ vm_name }}
   {%- if address_pool or hostname %}
   annotations:
     {%- if address_pool %}
@@ -10,19 +13,16 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
     {%- endif %}
   {%- endif %}
-  labels:
-    kubevirt.io/vm: {{ vm_name }}
-  name: {{ vm_name }}
 spec:
   ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local
   ports:
-{% for port in service_ports %}
+  {%- for port in service_ports %}
   - name: {{ port.port_name }}
     port: {{ port.port }}
     protocol: {{ port.protocol }}
     targetPort: {{ port.targetPort }}
-{% endfor %}
+  {%- endfor %}
   selector:
     kubevirt.io/vm: {{ vm_name }}
   type: LoadBalancer

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {%- if address_pool or hostname %}
+  labels:
+    kubevirt.io/vm: {{ vm_name }}
+  name: {{ vm_name }}
+{%- if address_pool or hostname %}
   annotations:
     {%- if address_pool %}
     metallb.universe.tf/address-pool: {{ address_pool }}
@@ -9,10 +12,8 @@ metadata:
     {%- if hostname %}
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
     {%- endif %}
-  {%- endif %}
-  labels:
-    kubevirt.io/vm: {{ vm_name }}
-  name: {{ vm_name }}
+{%- endif %}
+
 spec:
   ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -8,6 +8,9 @@ metadata:
     {%- if hostname %}
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
     {%- endif %}
+  {%- if not address_pool and not hostname %}
+  annotations: {}
+  {%- endif %}
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    kubevirt.io/vm: {{ vm_name }}
-  name: {{ vm_name }}
 {%- if address_pool or hostname %}
   annotations:
     {%- if address_pool %}
@@ -13,6 +10,9 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
     {%- endif %}
 {%- endif %}
+  labels:
+    kubevirt.io/vm: {{ vm_name }}
+  name: {{ vm_name }}
 spec:
   ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,17 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {%- if address_pool or hostname %}
-  annotations:
-    {%- if address_pool %}
-    metallb.universe.tf/address-pool: {{ address_pool }}
-    {%- endif %}
-    {%- if hostname %}
-    external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
-    {%- endif %}
-  {%- else %}
   annotations: {}
-  {%- endif %}
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,20 +1,24 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations: {}
+  annotations:
+    metallb.universe.tf/address-pool: {{ address_pool }}
+    external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}
 spec:
+  ipFamilyPolicy: PreferDualStack
+  externalTrafficPolicy: Local
   ports:
-  {%- for port in service_ports %}
+{% for port in service_ports %}
   - name: {{ port.port_name }}
     port: {{ port.port }}
     protocol: {{ port.protocol }}
     targetPort: {{ port.targetPort }}
-  {%- endfor %}
+{% endfor %}
   selector:
     kubevirt.io/vm: {{ vm_name }}
-  type: {{ service_type if service_type else 'ClusterIP' }}
+  type: LoadBalancer
 status:
   loadBalancer: {}

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -15,7 +15,9 @@ metadata:
 {% endif %}
 spec:
   ipFamilyPolicy: PreferDualStack
+  {% if service_type == 'LoadBalancer' %}
   externalTrafficPolicy: Local
+  {% endif %}
   ports:
 {% for port in service_ports %}
   - name: {{ port.port_name }}

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,9 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {%- if address_pool or hostname %}
   annotations:
+    {%- if address_pool %}
     metallb.universe.tf/address-pool: {{ address_pool }}
+    {%- endif %}
+    {%- if hostname %}
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
+    {%- endif %}
+  {%- endif %}
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -2,14 +2,16 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    metallb.universe.tf/address-pool: {{ address_pool }}
-    external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
+    {% if address_pool %}metallb.universe.tf/address-pool: {{ address_pool }}{% endif %}
+    {% if hostname %}external-dns.alpha.kubernetes.io/hostname: {{ hostname }}{% endif %}
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}
 spec:
+  {% if service_type == 'LoadBalancer' %}
   ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local
+  {% endif %}
   ports:
 {% for port in service_ports %}
   - name: {{ port.port_name }}
@@ -19,6 +21,6 @@ spec:
 {% endfor %}
   selector:
     kubevirt.io/vm: {{ vm_name }}
-  type: LoadBalancer
+  type: {{ service_type }}
 status:
   loadBalancer: {}

--- a/app/templates/service.yaml.j2
+++ b/app/templates/service.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {%- if address_pool or hostname %}
+{%- if address_pool or hostname %}
   annotations:
     {%- if address_pool %}
     metallb.universe.tf/address-pool: {{ address_pool }}
@@ -9,7 +9,7 @@ metadata:
     {%- if hostname %}
     external-dns.alpha.kubernetes.io/hostname: {{ hostname }}
     {%- endif %}
-  {%- endif %}
+{%- endif %}
   labels:
     kubevirt.io/vm: {{ vm_name }}
   name: {{ vm_name }}

--- a/app/templates/terminal.html
+++ b/app/templates/terminal.html
@@ -17,11 +17,7 @@
             background: '#000000',
             foreground: '#ffffff'
         }
-    }
-
-    // Handle form submission (both button click and Enter key)
-    document.getElementById('sshLoginForm').addEventListener('submit', connectSSH);
-    document.getElementById('sshConnect').addEventListener('click', connectSSH);
+    });
     const fitAddon = new FitAddon.FitAddon();
     term.loadAddon(fitAddon);
     
@@ -52,7 +48,10 @@
     `;
     document.body.appendChild(loginForm);
 
-    function connectSSH() {
+    function connectSSH(event) {
+        if (event) {
+            event.preventDefault();
+        }
         const username = document.getElementById('sshUsername').value;
         const password = document.getElementById('sshPassword').value;
         
@@ -103,6 +102,12 @@
             console.error('WebSocket error:', error);
             term.write('\r\nWebSocket error occurred\r\n');
         };
+    }
+
+    // Add event listeners after DOM is loaded
+    document.addEventListener('DOMContentLoaded', function() {
+        document.getElementById('sshLoginForm').addEventListener('submit', connectSSH);
+        document.getElementById('sshConnect').addEventListener('click', connectSSH);
     });
 
     // Handle window resize

--- a/app/templates/terminal.html
+++ b/app/templates/terminal.html
@@ -17,7 +17,11 @@
             background: '#000000',
             foreground: '#ffffff'
         }
-    });
+    }
+
+    // Handle form submission (both button click and Enter key)
+    document.getElementById('sshLoginForm').addEventListener('submit', connectSSH);
+    document.getElementById('sshConnect').addEventListener('click', connectSSH);
     const fitAddon = new FitAddon.FitAddon();
     term.loadAddon(fitAddon);
     
@@ -31,15 +35,17 @@
             <div class="card" style="width: 300px;">
                 <div class="card-body">
                     <h5 class="card-title mb-3">SSH Authentication</h5>
-                    <div class="mb-3">
-                        <label class="form-label">Username</label>
-                        <input type="text" class="form-control" id="sshUsername">
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Password</label>
-                        <input type="password" class="form-control" id="sshPassword">
-                    </div>
-                    <button class="btn btn-primary w-100" id="sshConnect">Connect</button>
+                    <form id="sshLoginForm" onsubmit="return false;">
+                        <div class="mb-3">
+                            <label class="form-label">Username</label>
+                            <input type="text" class="form-control" id="sshUsername">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Password</label>
+                            <input type="password" class="form-control" id="sshPassword">
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100" id="sshConnect">Connect</button>
+                    </form>
                 </div>
             </div>
         </div>

--- a/app/templates/terminal.html
+++ b/app/templates/terminal.html
@@ -52,7 +52,7 @@
     `;
     document.body.appendChild(loginForm);
 
-    document.getElementById('sshConnect').addEventListener('click', () => {
+    function connectSSH() {
         const username = document.getElementById('sshUsername').value;
         const password = document.getElementById('sshPassword').value;
         

--- a/app/templates/vm.yaml.j2
+++ b/app/templates/vm.yaml.j2
@@ -46,6 +46,7 @@ spec:
         - name: {{ vm_name }}-pvc
           persistentVolumeClaim:
             claimName: {{ vm_name }}-pvc
+        {% if user_data %}
         - name: cloudinitdisk
           cloudInitNoCloud:
             networkData: |-
@@ -61,6 +62,7 @@ spec:
                         gateway: fd10:0:2::1
             userData: |-
 {{ user_data | indent(14, True) }}
+        {% endif %}
   dataVolumeTemplates:
     - metadata:
         name: {{ vm_name }}-pvc
@@ -71,7 +73,7 @@ spec:
             requests:
               storage: {{ storage_size }}Gi
           accessModes:
-            - ReadWriteMany
+            - {{ storage_access_mode }}
           storageClassName: {{ storage_class }}
         source:
           http:

--- a/app/templates/vm.yaml.j2
+++ b/app/templates/vm.yaml.j2
@@ -61,7 +61,7 @@ spec:
                         gateway: fd10:0:2::1
             {% if user_data and user_data.strip() %}
             userData: |-
-              {{ user_data }}
+{{ user_data | indent(14, True) }}
             {% endif %}
   dataVolumeTemplates:
     - metadata:

--- a/app/templates/vm.yaml.j2
+++ b/app/templates/vm.yaml.j2
@@ -61,7 +61,7 @@ spec:
                         gateway: fd10:0:2::1
             {% if user_data and user_data.strip() %}
             userData: |-
-              {{ user_data | indent(14, True) }}
+{{ user_data | indent(14, True) }}
             {% endif %}
   dataVolumeTemplates:
     - metadata:

--- a/app/templates/vm.yaml.j2
+++ b/app/templates/vm.yaml.j2
@@ -46,7 +46,6 @@ spec:
         - name: {{ vm_name }}-pvc
           persistentVolumeClaim:
             claimName: {{ vm_name }}-pvc
-        {% if user_data %}
         - name: cloudinitdisk
           cloudInitNoCloud:
             networkData: |-
@@ -60,9 +59,10 @@ spec:
                       - type: static6
                         address: fd10:0:2::2/120
                         gateway: fd10:0:2::1
+            {% if user_data %}
             userData: |-
 {{ user_data | indent(14, True) }}
-        {% endif %}
+            {% endif %}
   dataVolumeTemplates:
     - metadata:
         name: {{ vm_name }}-pvc

--- a/app/templates/vm.yaml.j2
+++ b/app/templates/vm.yaml.j2
@@ -59,8 +59,10 @@ spec:
                       - type: static6
                         address: fd10:0:2::2/120
                         gateway: fd10:0:2::1
+            {% if user_data %}
             userData: |-
-              {{ user_data if user_data else '#cloud-config' }}
+              {{ user_data }}
+            {% endif %}
   dataVolumeTemplates:
     - metadata:
         name: {{ vm_name }}-pvc

--- a/app/templates/vm.yaml.j2
+++ b/app/templates/vm.yaml.j2
@@ -59,10 +59,8 @@ spec:
                       - type: static6
                         address: fd10:0:2::2/120
                         gateway: fd10:0:2::1
-            {% if user_data %}
             userData: |-
-{{ user_data | indent(14, True) }}
-            {% endif %}
+              {{ user_data if user_data else '#cloud-config' }}
   dataVolumeTemplates:
     - metadata:
         name: {{ vm_name }}-pvc
@@ -73,7 +71,7 @@ spec:
             requests:
               storage: {{ storage_size }}Gi
           accessModes:
-            - {{ storage_access_mode }}
+            - {{ storage_access_mode if storage_access_mode else 'ReadWriteMany' }}
           storageClassName: {{ storage_class }}
         source:
           http:

--- a/app/templates/vm.yaml.j2
+++ b/app/templates/vm.yaml.j2
@@ -61,7 +61,7 @@ spec:
                         gateway: fd10:0:2::1
             {% if user_data and user_data.strip() %}
             userData: |-
-{{ user_data | indent(14, True) }}
+              {{ user_data | indent(14, True) }}
             {% endif %}
   dataVolumeTemplates:
     - metadata:

--- a/app/templates/vm.yaml.j2
+++ b/app/templates/vm.yaml.j2
@@ -59,7 +59,7 @@ spec:
                       - type: static6
                         address: fd10:0:2::2/120
                         gateway: fd10:0:2::1
-            {% if user_data %}
+            {% if user_data and user_data.strip() %}
             userData: |-
               {{ user_data }}
             {% endif %}

--- a/app/templates/vm_list.html
+++ b/app/templates/vm_list.html
@@ -73,7 +73,9 @@
                     
                     <div class="small text-muted mb-3">
                         <div><i class="bi bi-box me-2"></i>Image: {{ vm.image.split('/')[-1] }}</div>
+                        {% if config.METALLB_ENABLED %}
                         <div><i class="bi bi-diagram-2 me-2"></i>Network Pool: {{ vm.address_pool }}</div>
+                        {% endif %}
                         {% if vm.tags %}
                         <div class="mt-2">
                             <i class="bi bi-tags me-2"></i>Tags:

--- a/app/utils.py
+++ b/app/utils.py
@@ -65,8 +65,8 @@ def generate_yaml(form_data, config):
     logger.info(f"Generating YAML for VM: {form_data['vm_name']}")
     try:
         # Process user data
-        user_data = form_data['user_data'].strip()
-        if not user_data.startswith('#cloud-config'):
+        user_data = form_data['user_data'].strip() if form_data.get('user_data') else ''
+        if user_data and not user_data.startswith('#cloud-config'):
             user_data = '#cloud-config\n' + user_data
 
         # Prepare template data

--- a/app/utils.py
+++ b/app/utils.py
@@ -91,7 +91,7 @@ def generate_yaml(form_data, config):
                 }
                 for port in form_data['service_ports']
             ],
-            'service_type': form_data.get('service_type', 'LoadBalancer')
+            'service_type': form_data['service_type']
         }
 
         # Render templates

--- a/app/utils.py
+++ b/app/utils.py
@@ -206,7 +206,7 @@ def get_vm_list(config):
                                         'image': image_url,
                                         'address_pool': service_config.get('metadata', {}).get('annotations', {}).get('metallb.universe.tf/address-pool', 'default'),
                                         'tags': tags,
-                                        'service_type': service_config.get('spec', {}).get('type', 'LoadBalancer')
+                                        'service_type': service_config.get('spec', {}).get('type')
                                     }
                                     vms.append(vm_info)
                                     logger.debug(f"Added VM to list: {vm_info['name']}")
@@ -295,7 +295,7 @@ def get_vm_config(config, vm_name):
                 }
                 for port in service_config['spec']['ports']
             ],
-            'service_type': service_config.get('spec', {}).get('type', 'LoadBalancer')
+            'service_type': service_config.get('spec', {}).get('type')
         }
 
 def update_vm_config(config, vm_name, form_data):

--- a/app/utils.py
+++ b/app/utils.py
@@ -90,7 +90,8 @@ def generate_yaml(form_data, config):
                     'targetPort': port['targetPort']
                 }
                 for port in form_data['service_ports']
-            ]
+            ],
+            'service_type': form_data.get('service_type', 'LoadBalancer')
         }
 
         # Render templates

--- a/app/utils.py
+++ b/app/utils.py
@@ -192,10 +192,10 @@ def get_vm_list(config):
                                 'name': vm_config['metadata']['name'],
                                 'cpu': vm_config['spec']['template']['spec']['domain']['cpu']['cores'],
                                 'memory': memory,
-                                'hostname': service_config['metadata']['annotations'].get('external-dns.alpha.kubernetes.io/hostname', 'N/A'),
+                                'hostname': service_config.get('metadata', {}).get('annotations', {}).get('external-dns.alpha.kubernetes.io/hostname', 'N/A'),
                                 'storage': vm_config['spec']['dataVolumeTemplates'][0]['spec']['storage']['resources']['requests']['storage'],
                                 'image': vm_config['spec']['dataVolumeTemplates'][0]['spec']['source']['http']['url'],
-                                'address_pool': service_config['metadata']['annotations'].get('metallb.universe.tf/address-pool', 'default'),
+                                'address_pool': service_config.get('metadata', {}).get('annotations', {}).get('metallb.universe.tf/address-pool', 'default'),
                                 'tags': tags
                             }
                             vms.append(vm_info)

--- a/app/utils.py
+++ b/app/utils.py
@@ -60,7 +60,7 @@ def ensure_git_clone(config):
         logger.error(f"Error ensuring Git clone: {str(e)}")
         raise
 
-def generate_yaml(form_data):
+def generate_yaml(form_data, config):
     """Generate YAML configuration using Jinja2 templates."""
     logger.info(f"Generating YAML for VM: {form_data['vm_name']}")
     try:
@@ -71,6 +71,7 @@ def generate_yaml(form_data):
 
         # Prepare template data
         template_data = {
+            'config': config,
             'vm_name': form_data['vm_name'],
             'cpu_cores': form_data['cpu_cores'],
             'memory': form_data['memory'],
@@ -270,7 +271,7 @@ def get_vm_config(config, vm_name):
 def update_vm_config(config, vm_name, form_data):
     """Update VM configuration in Git repository."""
     # Generate YAML content
-    yaml_content = generate_yaml(form_data)
+    yaml_content = generate_yaml(form_data, Config)
     
     # Prepare Git configuration
     git_config = {

--- a/app/utils.py
+++ b/app/utils.py
@@ -205,7 +205,8 @@ def get_vm_list(config):
                                         'storage': storage,
                                         'image': image_url,
                                         'address_pool': service_config.get('metadata', {}).get('annotations', {}).get('metallb.universe.tf/address-pool', 'default'),
-                                        'tags': tags
+                                        'tags': tags,
+                                        'service_type': service_config.get('spec', {}).get('type', 'LoadBalancer')
                                     }
                                     vms.append(vm_info)
                                     logger.debug(f"Added VM to list: {vm_info['name']}")
@@ -289,11 +290,12 @@ def get_vm_config(config, vm_name):
                 {
                     'port_name': port['name'],  # Changed from 'name' to 'port_name' to match form field
                     'port': port['port'],
-'protocol': port['protocol'],
+                    'protocol': port['protocol'],
                     'targetPort': port['targetPort']
                 }
                 for port in service_config['spec']['ports']
-            ]
+            ],
+            'service_type': service_config.get('spec', {}).get('type', 'LoadBalancer')
         }
 
 def update_vm_config(config, vm_name, form_data):

--- a/config.py
+++ b/config.py
@@ -17,6 +17,9 @@ class Config:
     
     # Git clone directory
     GIT_CLONE_DIR = os.getenv('GIT_CLONE_DIR', '/app/storage/clones')
+    
+    # Feature flags
+    EXTERNAL_DNS_ENABLED = os.getenv('EXTERNAL_DNS_ENABLED', 'false').lower() == 'true'
 
     def __init__(self):
         # Validate immediately during initialization

--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ class Config:
     
     # Feature flags
     EXTERNAL_DNS_ENABLED = os.getenv('EXTERNAL_DNS_ENABLED', 'false').lower() == 'true'
+    METALLB_ENABLED = os.getenv('METALLB_ENABLED', 'false').lower() == 'true'
 
     def __init__(self):
         # Validate immediately during initialization


### PR DESCRIPTION
# Feature: Optional MetalLB and ExternalDNS Integration

## Description
This PR adds optional integration with MetalLB and ExternalDNS, allowing for more flexible network configuration of virtual machines.

### Added
- ExternalDNS Integration:
  - Enable with `EXTERNAL_DNS_ENABLED=true`
  - Automatically manages DNS records for VMs
  - Configurable through hostname field in VM creation
  - Adds `external-dns.alpha.kubernetes.io/hostname` annotation to Services
  - Example: `external-dns.alpha.kubernetes.io/hostname: myvm.example.com`

- MetalLB Integration:
  - Enable with `METALLB_ENABLED=true`
  - Provides LoadBalancer services for VMs
  - Configurable IP address pools via annotations
  - Adds `metallb.universe.tf/address-pool` annotation to Services
  - Example: `metallb.universe.tf/address-pool: production-pool`

### Changed
- Improved error handling for Git operations
- Better feedback for configuration issues
- Updated documentation for new environment variables
- Enhanced service configuration options
- Improved network integration capabilities

## Testing Done
- Verified MetalLB integration with test VM deployments
- Confirmed ExternalDNS record creation
- Tested both features in isolation and together
- Validated error handling for misconfigured scenarios

## Notes
- Both features are optional and disabled by default
- Configuration is done via environment variables
- Existing deployments without these features will continue to work as before
